### PR TITLE
Update to Django 1.10.0

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -29,7 +29,7 @@ Quickstart
    going to use the ``{% request_id %}`` template tag).
 
 3. Add ``request_id.middleware.RequestIdMiddleware`` to the top of
-   ``MIDDLEWARE_CLASSES``.
+   ``MIDDLEWARE``.
 
 4. The app integrates with the standard Python/Django logging by defining
    a filter that puts a ``request_id`` variable in scope of every log message.
@@ -122,7 +122,7 @@ Quickstart
 Dependencies
 ------------
 
-``django-request-id`` depends on ``django-appconf>=0.6``.
+``django-request-id`` depends on ``django-appconf>=0.6`` and requires Django 1.10.0 or later.
 
 Documentation
 -------------

--- a/demo.py
+++ b/demo.py
@@ -13,7 +13,7 @@ import logging
 import os
 
 from django.conf import settings
-from django.conf.urls import patterns, url
+from django.conf.urls import url
 from django.core.wsgi import get_wsgi_application
 
 basename = os.path.splitext(os.path.basename(__file__))[0]
@@ -30,12 +30,17 @@ if not settings.configured:
         DEBUG=True,
         TIMEZONE="UTC",
         INSTALLED_APPS=["request_id"],
-        MIDDLEWARE_CLASSES=["request_id.middleware.RequestIdMiddleware"],
+        MIDDLEWARE=["request_id.middleware.RequestIdMiddleware"],
         ROOT_URLCONF=basename,
         WSGI_APPLICATION="{}.application".format(basename),
-        TEMPLATE_DIRS=[rel("tests", "templates")],
-        TEMPLATE_CONTEXT_PROCESSORS=[
-            "django.core.context_processors.request"
+        TEMPLATES=[
+            {
+                'DIRS': [rel("tests", "templates")],
+                'BACKEND': 'django.template.backends.django.DjangoTemplates',
+                'OPTIONS': {
+                    'context_processors': [ "django.template.context_processors.request" ],
+                },
+            },
         ],
         LOGGING={
             "version": 1,
@@ -96,9 +101,9 @@ class HelloView(TemplateView):
         return super(HelloView, self).render_to_response(context, **response_kwargs)
 
 
-urlpatterns = patterns("",
+urlpatterns = [
     url(r"^$", HelloView.as_view())
-)
+]
 
 
 # WSGI

--- a/request_id/middleware.py
+++ b/request_id/middleware.py
@@ -16,12 +16,15 @@ def get_request_id(request):
 
 
 class RequestIdMiddleware(object):
+    def __init__(self, get_response):
+        self.get_response = get_response
 
-    def process_request(self, request):
+    def __call__(self, request):
         request_id = get_request_id(request)
         request.request_id = request_id
         local.request_id = request_id
 
-    def process_response(self, request, response):
+        response = self.get_response(request)
+
         release_local(local)
         return response

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-django
+django>=1.10.0
 django-appconf>=0.6

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ try:
 except ImportError:
     from distutils.core import setup
 
-version = "0.1.0"
+version = "0.2.0"
 
 if sys.argv[-1] == "publish":
     os.system("python setup.py sdist bdist_wheel upload")
@@ -35,7 +35,7 @@ setup(
     ],
     include_package_data=True,
     install_requires=[
-        "django",
+        "django>=1.10.0",
         "django-appconf>=0.6"
     ],
     zip_safe=False,


### PR DESCRIPTION
The new Django 1.10 release uses a [different middleware API](https://docs.djangoproject.com/en/1.9/topics/http/middleware/#upgrading-middleware).  There's backwards compatibility if you use the old `MIDDLEWARE_CLASSES` setting, but that's deprecated in favour of the new `MIDDLEWARE` setting.

This patch updates the request id middleware to the new API, the `demo.py` demo project is updated to use the newer Django `TEMPLATES` setting and makes Django 1.10 a hard dependency because the new middleware API is not backwards compatible.

Because of the backwards incompatible change, I bumped the version of django-request-id to 0.2.0.
