### PR TITLE
Seed Lua's number generator on nginx worker init

### DIFF
--- a/docs/server-config.rst
+++ b/docs/server-config.rst
@@ -40,6 +40,24 @@ and add it to server logs using the following snippets:
                           '$status $body_bytes_sent "$http_referer" '
                           '"$http_user_agent" "$http_x_forwarded_for" '
                           'request_id=$request_id';
+
+        init_worker_by_lua_block {
+            -- Solution that should work on any OS, but might not
+            -- be random enough:
+            -- math.randomseed(os.time())
+
+            -- Solution that should work on Unix-like systems
+            -- Random number up to 4294967296 (256^4)
+            local urandom = assert(io.open("/dev/urandom", "rb"))
+            local seed = urandom:read(4)
+            urandom:close()
+            local seed_as_number = 0
+            for i = 1, #seed do
+              seed_as_number = 256 * seed_as_number + seed:byte(i)
+            end
+            math.randomseed(seed_as_number)
+        }
+
         ...
     }
 


### PR DESCRIPTION
During testing I discovered Lua doesn't seed itself, resulting in the same request IDs showing in my logs. I've implemented seeding for Unix-like systems using `/dev/urandom`; Lots of pages on the internet suggest `os.time()` but this seems like it would make different nginx workers seed with the same number which is undesirable (but I'm no expert, so I could be wrong).
```
--restarted nginx (no seed)
::1 - - [15/Aug/2017:15:05:26 +0200] "GET / HTTP/1.1" request_id=KSG6-N7L5TK0U-1TMT69XB
::1 - - [15/Aug/2017:15:05:26 +0200] "GET / HTTP/1.1" request_id=U01R-EYZDA9VY-LR2DNYQ3
::1 - - [15/Aug/2017:15:05:26 +0200] "GET / HTTP/1.1" request_id=2OJS-2IPJ3N27-TOZOTZDD
--restarted nginx (no seed)
::1 - - [15/Aug/2017:15:05:33 +0200] "GET / HTTP/1.1" request_id=KSG6-N7L5TK0U-1TMT69XB
::1 - - [15/Aug/2017:15:05:33 +0200] "GET / HTTP/1.1" request_id=U01R-EYZDA9VY-LR2DNYQ3
::1 - - [15/Aug/2017:15:05:33 +0200] "GET / HTTP/1.1" request_id=2OJS-2IPJ3N27-TOZOTZDD
--restarted nginx (seeded)
::1 - - [15/Aug/2017:15:05:45 +0200] "GET / HTTP/1.1" request_id=EQKT-I0AA72YT-S5A9GSN9
::1 - - [15/Aug/2017:15:05:45 +0200] "GET / HTTP/1.1" request_id=EIXC-X5J1ANTW-KJXZS8BE
::1 - - [15/Aug/2017:15:05:45 +0200] "GET / HTTP/1.1" request_id=TWNB-360U791Q-DNNEOK1O
--restarted nginx (seeded)
::1 - - [15/Aug/2017:15:05:55 +0200] "GET / HTTP/1.1" request_id=SF8O-V264GYXS-24408CF5
::1 - - [15/Aug/2017:15:05:55 +0200] "GET / HTTP/1.1" request_id=DRUE-C66R00Q3-7XSW5YZP
::1 - - [15/Aug/2017:15:05:55 +0200] "GET / HTTP/1.1" request_id=89KS-FZR9M8RB-5R0I1S3A
```

